### PR TITLE
Remove `causaldata_instrumental` module and related tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ See scenario notebooks: https://causalis.causalcraft.com/explore-scenarios
 
 # [Contributing guidelines](https://github.com/causalis-causalcraft/Causalis?tab=contributing-ov-file)
 
-# Acknowledgements
+# Maintainers
+
+[Ioann Martynov](https://www.linkedin.com/in/ioannmartynov/)
+
+# References
 
 https://github.com/DoubleML/doubleml-for-py

--- a/README.md
+++ b/README.md
@@ -61,21 +61,23 @@ result.summary()
 
 # Pick your scenario
 
-**Classic RCT**: randomized assignment (no pre-period metric).
+**[Classic RCT](https://causalis.causalcraft.com/articles/classic_rct)**: randomized assignment (no pre-period metric).
 
-**CUPED**: randomized assignment with pre-period metric for variance reduction.
+**[CUPED](https://causalis.causalcraft.com/articles/cuped)**: randomized assignment with pre-period metric for variance reduction.
 
-**Unconfoundedness**: observational study adjusting for measured confounders (DML IRM).
+**[Unconfoundedness](https://causalis.causalcraft.com/articles/uncofoundedness)**: observational study adjusting for measured confounders (DML IRM).
 
-**GATE**: Subgroup treatment effects built on top of an observational IRM workflow.
+**[GATE](https://causalis.causalcraft.com/articles/gate)**: Subgroup treatment effects built on top of an observational IRM workflow.
 
-**Multi Unconfoundedness**: Multi Unconfoundedness extends observational identification to multiple treatment arms. We estimate causal contrasts across arms by adjusting for observed confounders and modeling generalized propensity scores.
+**[Multi Unconfoundedness](https://causalis.causalcraft.com/articles/multi_unconfoundedness)**: Multi Unconfoundedness extends observational identification to multiple treatment arms. We estimate causal contrasts across arms by adjusting for observed confounders and modeling generalized propensity scores.
 
-**Synthetic Control**: Single treated-unit panel setups matched against a weighted synthetic donor pool.
+**[Synthetic Control*](https://causalis.causalcraft.com/articles/synthetic_control)*: Single treated-unit panel setups matched against a weighted synthetic donor pool.
 
-**Difference in Difference**: causal effects by comparing the changes in outcomes over time between a treatment group and a control group based on parallel trends
+**[Difference in Difference*](https://causalis.causalcraft.com/articles/did)*: causal effects by comparing the changes in outcomes over time between a treatment group and a control group based on parallel trends
 
-**Uplift / CATE scoring**: Uplift modeling estimates the Conditional Average Treatment Effect (CATE) for individual units, enabling optimal targeting and personalized decision making.
+**[Uplift / CATE scoring](https://causalis.causalcraft.com/articles/uplift)**: Uplift modeling estimates the Conditional Average Treatment Effect (CATE) for individual units, enabling optimal targeting and personalized decision making.
+
+[Introduction to Causal Inference](https://causalis.causalcraft.com/articles/introduction-to-causal-inference): guide
 
 See scenario notebooks: https://causalis.causalcraft.com/explore-scenarios
 


### PR DESCRIPTION
## What changed?
- Removed the `causaldata_instrumental` module, including implementations of `InstrumentalGenerator` and `CausalDataInstrumental`.
- Deleted unused utility functions and placeholder IV DGP helpers in `functional.py`.
- Removed unit tests associated with the `causaldata_instrumental` module.
- Cleaned up related references in the API documentation.

## Why?
- The `causaldata_instrumental` module is outdated and no longer necessary.
- To simplify the codebase and eliminate unused components with no active dependencies.

## Tests added/updated?
- [ ] Yes (please describe)
- [ ] No (please explain why)

## Docs/notebooks updated?
- [ ] Yes (please link)
- [ ] No